### PR TITLE
Improve core component interaction contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ private in `package.json` and is **not published as an installable npm package**
 Do not confuse it with the unrelated `border-1px` package on npm.
 
 - [Documentation](https://border1px.github.io/border-ui/docs/FAQ/introduction.html)
+- [Maintained component API](docs/FAQ/component-api.md)
 - [Interactive demo](https://border1px.github.io/border-ui/)
 - [Maintenance roadmap](ROADMAP.md)
 - [How to contribute](CONTRIBUTING.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,7 +32,7 @@ clearer.
 ## Milestone 4: modernization
 
 - [x] Define the supported browser baseline.
-- [ ] Define the supported component API.
+- [x] Define the supported component API.
 - [ ] Plan migration from Vue 2 and Vue CLI to Vue 3 and Vite.
 - [ ] Migrate VuePress 1 to a maintained documentation toolchain.
 - [ ] Add component tests and visual regression coverage.

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,6 +41,7 @@ module.exports = {
         children: [
           ['/FAQ/introduction','介绍'],
           ['/FAQ/quickstart','快速上手'],
+          ['/FAQ/component-api','组件 API 维护基线'],
           ['/FAQ/changelog','更新日志'],
           ['/FAQ/aboutme','与我有关'],
         ]

--- a/docs/Comp/button.md
+++ b/docs/Comp/button.md
@@ -50,6 +50,14 @@
 </Common-code-format>
 </ClientOnly> 
 
+#### 原生按钮类型
+组件默认渲染为 `type="button"`，避免在表单中被浏览器当作提交按钮。
+需要提交或重置表单时，可以显式设置 `native-type="submit"` 或 `native-type="reset"`。
+
+```vue
+<bo-button native-type="submit">提交</bo-button>
+```
+
 
 #### 满屏按钮
 属性auto会让按钮占满屏幕宽度
@@ -87,4 +95,7 @@
 | size          | 可选值为：large、normal、small              | String | normal |
 | color         | 自定义RGB颜色                               | String | #2196F3 |
 | auto          | 宽度100%                                   | Boolean | False |
-| loading       | 加载状态                                   | Boolean | False |
+| loading       | 加载状态，同时禁用按钮                      | Boolean | False |
+| loading-txt   | 加载状态显示文本                            | String | 加载中 |
+| disabled      | 禁用状态                                   | Boolean | False |
+| native-type   | 原生按钮类型：button、submit、reset          | String | button |

--- a/docs/Comp/cell.md
+++ b/docs/Comp/cell.md
@@ -40,6 +40,9 @@ Cell组件一般会成组的出现，由一个Cell包裹着多个CellItem来使�
 
 ```clickable```属性同样会有点击背景高亮效果，但它不会有右侧箭头。
 
+设置 `isLink` 或 `clickable` 后，CellItem 会进入键盘焦点顺序，并支持 Enter
+或 Space 触发 `click` 事件。
+
 <ClientOnly>
 <Common-code-format>
   <highlight-code slot="codeText" lang="vue">
@@ -107,6 +110,8 @@ Cell组件一般会成组的出现，由一个Cell包裹着多个CellItem来使�
 | isLink        | 是否作为链接显示(右侧有箭头+点击背景高亮)     | Boolean | false |
 | clickable     | 是否可点击(点击背景高亮)                     | Boolean | False |
 | icon          | cell-item左侧icon图标                       | Boolean | False |
+
+交互式 CellItem 在鼠标点击、Enter 或 Space 激活时触发 `click` 事件。
 
 #### Cell
 | 参数           | 说明                                      | 类型   | 默认值

--- a/docs/Comp/switch.md
+++ b/docs/Comp/switch.md
@@ -13,7 +13,7 @@
 <ClientOnly>
 <Common-code-format>
   <highlight-code slot="codeText" lang="vue">
-    <bo-switch :value=true></bo-switch>
+    <bo-switch v-model="enabled"></bo-switch>
   </highlight-code>
 </Common-code-format>
 </ClientOnly> 
@@ -41,10 +41,12 @@ export default {
 | 参数           | 说明                                        | 类型    | 默认值
 | ------------- |:--------------------------------------------| :-----: | :-----: |
 | value         | 是否选中                                     | Boolean  | False     |
+| disabled      | 是否禁用                                     | Boolean  | False     |
+| aria-label    | 无可见文本时使用的无障碍名称                   | String   |           |
 
 
 ## events
 | 参数           | 说明              | 类型        | 默认值
 | ------------- |:------------------| :---------: | :-----: |
 | change        | switch开关回调事件 |  Function   |         |
-
+| input         | Vue 2 v-model 更新事件 | Function |         |

--- a/docs/FAQ/changelog.md
+++ b/docs/FAQ/changelog.md
@@ -7,6 +7,8 @@
 6. 恢复应用构建、代码检查和 VuePress 文档构建
 7. 增加 GitHub Actions、生产依赖安全门禁及低噪声 Dependabot 配置
 8. 增加 Button、Switch、Cell 组件 smoke tests，并明确移动端浏览器支持基线
+9. 完善 Switch 的 Vue 2 v-model、Button 表单安全和 CellItem 键盘操作契约
+10. 增加核心组件 API 维护基线及对应回归测试
 
 ### 2019-08-08
 1. 增加Picker组件

--- a/docs/FAQ/component-api.md
+++ b/docs/FAQ/component-api.md
@@ -1,0 +1,45 @@
+# 组件 API 维护基线
+
+borderUI 恢复维护后，将文档、单元测试和持续集成共同覆盖的接口视为当前维护基线。
+现阶段该基线优先覆盖 `Button`、`Switch`、`Cell` 和 `CellItem`；其他历史组件仍可使用，
+但在补齐自动化验证前，其接口应视为待确认状态。
+
+## 稳定交互契约
+
+### Button
+
+- `type` 只控制 borderUI 的视觉样式。
+- `nativeType` 控制原生按钮类型，可选 `button`、`submit`、`reset`，默认 `button`。
+- `disabled` 或 `loading` 为 `true` 时，原生按钮会被禁用。
+- `loading` 状态会通过 `aria-busy` 暴露给辅助技术。
+- 点击时触发 `click`，参数为原生鼠标事件。
+
+### Switch
+
+- 支持 Vue 2 的 `v-model`：读取 `value`，切换后触发 `input`。
+- 每次切换同时触发 `change`，两个事件的参数均为最新布尔值。
+- 外部更新 `value` 后，原生复选框状态会同步更新。
+- 支持 `disabled`；无可见文本时可通过 `ariaLabel` 提供无障碍名称。
+
+```vue
+<bo-switch
+  v-model="enabled"
+  aria-label="启用通知"
+  @change="onChange"
+/>
+```
+
+### Cell 与 CellItem
+
+- `Cell` 继续作为 `CellItem` 的分组容器。
+- `isLink` 或 `clickable` 为 `true` 时，`CellItem` 具有按钮语义并进入键盘焦点顺序。
+- 交互式 `CellItem` 支持鼠标点击、Enter 和 Space 激活，并触发 `click`。
+- 静态 `CellItem` 不会声明按钮语义。
+
+## 兼容性与变更原则
+
+维护基线使用 Vue 2.6.14、Node.js 22 和仓库锁文件。浏览器范围见
+[Supported environments](https://github.com/border1px/borderUI#supported-environments)。
+
+对上述契约的修复会增加回归测试。潜在破坏性变更将先记录在路线图和变更日志中；
+在 Vue 3 迁移方案确定前，不承诺历史实验组件的接口保持不变。

--- a/src/components/button/button.vue
+++ b/src/components/button/button.vue
@@ -3,14 +3,17 @@
     class = "pf-button"
     @click = "handleClick"
     :style = "styleObject"
+    :type = "nativeType"
     :disabled = "disabled || loading"
+    :aria-busy = "loading ? 'true' : null"
+    :aria-disabled = "disabled || loading ? 'true' : null"
     :class = "[
       type ? 'pf-button-' + type : '',
       size ? 'pf-button-' + size : '',
       {
         'is-square' : square,
         'is-auto' : auto,
-        'is-disabled': disabled
+        'is-disabled': disabled || loading
       }
     ]"
   >
@@ -31,6 +34,11 @@ export default {
     type: {
       type: String,
       default: 'primary'
+    },
+    nativeType: {
+      type: String,
+      default: 'button',
+      validator: value => ['button', 'submit', 'reset'].includes(value)
     },
     size: {
       type: String,

--- a/src/components/cell/cell-item.vue
+++ b/src/components/cell/cell-item.vue
@@ -1,8 +1,11 @@
 <template>
   <div
     class="cell-item"
-    :class="{ taphold : isLink || clickable }"
+    :class="{ taphold: interactive }"
+    :role="interactive ? 'button' : null"
+    :tabindex="interactive ? 0 : null"
     @click="onClick"
+    @keydown="onKeydown"
   >
     <div class="cell-item-inner">
       <div class="cell-icon" :class="icon" v-if="icon"></div>
@@ -30,9 +33,24 @@ export default {
     isLink: Boolean,
     clickable: Boolean
   },
+  computed: {
+    interactive () {
+      return this.isLink || this.clickable
+    }
+  },
   methods: {
     onClick () {
       this.$emit('click')
+    },
+    onKeydown (event) {
+      if (!this.interactive || event.target !== event.currentTarget) {
+        return
+      }
+
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        this.onClick()
+      }
     }
   }
 }

--- a/src/components/switch/switch.vue
+++ b/src/components/switch/switch.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="pf-switch">
-    <input type="checkbox" class="pf-switch-el" v-model="currentValue" @change="onChange">
+    <input
+      type="checkbox"
+      class="pf-switch-el"
+      :checked="value"
+      :disabled="disabled"
+      :aria-label="ariaLabel"
+      @change="onChange"
+    >
   </div>
 </template>
 
@@ -11,16 +18,16 @@ export default {
     value: {
       type: Boolean,
       default: false
-    }
-  },
-  data () {
-    return {
-      currentValue: this.value
-    }
+    },
+    disabled: Boolean,
+    ariaLabel: String
   },
   methods: {
-    onChange () {
-      this.$emit('change', this.currentValue)
+    onChange (event) {
+      const checked = event.target.checked
+
+      this.$emit('input', checked)
+      this.$emit('change', checked)
     }
   }
 }
@@ -59,5 +66,9 @@ export default {
 }
 .pf-switch-el:checked:before {
   left: 21px;
+}
+.pf-switch-el:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 </style>

--- a/tests/unit/button.spec.js
+++ b/tests/unit/button.spec.js
@@ -15,7 +15,18 @@ describe('BoButton', () => {
       'pf-button-primary',
       'pf-button-normal'
     ]))
+    expect(wrapper.attributes('type')).toBe('button')
     expect(wrapper.text()).toContain('Continue')
+  })
+
+  it('supports an explicit native button type', () => {
+    const wrapper = mount(Button, {
+      propsData: {
+        nativeType: 'submit'
+      }
+    })
+
+    expect(wrapper.attributes('type')).toBe('submit')
   })
 
   it('emits the native event when clicked', async () => {
@@ -41,8 +52,12 @@ describe('BoButton', () => {
     })
 
     expect(disabled.attributes('disabled')).toBe('disabled')
+    expect(disabled.attributes('aria-disabled')).toBe('true')
     expect(disabled.classes()).toContain('is-disabled')
     expect(loading.attributes('disabled')).toBe('disabled')
+    expect(loading.attributes('aria-busy')).toBe('true')
+    expect(loading.attributes('aria-disabled')).toBe('true')
+    expect(loading.classes()).toContain('is-disabled')
     expect(loading.text()).toContain('Please wait')
   })
 })

--- a/tests/unit/cell.spec.js
+++ b/tests/unit/cell.spec.js
@@ -32,6 +32,8 @@ describe('Cell components', () => {
 
     expect(CellItem.name).toBe('bo-cell-item')
     expect(wrapper.classes()).toContain('taphold')
+    expect(wrapper.attributes('role')).toBe('button')
+    expect(wrapper.attributes('tabindex')).toBe('0')
     expect(wrapper.get('.icon-right').exists()).toBe(true)
     expect(wrapper.get('.title-extra').text()).toBe('Required')
     expect(wrapper.get('.value-extra').text()).toBe('Now')
@@ -47,5 +49,28 @@ describe('Cell components', () => {
     await wrapper.trigger('click')
 
     expect(wrapper.emitted('click')).toHaveLength(1)
+  })
+
+  it('supports keyboard activation for interactive items', async () => {
+    const wrapper = mount(CellItem, {
+      propsData: {
+        clickable: true
+      }
+    })
+
+    await wrapper.trigger('keydown', { key: 'Enter' })
+    await wrapper.trigger('keydown', { key: ' ' })
+
+    expect(wrapper.emitted('click')).toHaveLength(2)
+  })
+
+  it('does not expose button semantics for static items', async () => {
+    const wrapper = mount(CellItem)
+
+    await wrapper.trigger('keydown', { key: 'Enter' })
+
+    expect(wrapper.attributes('role')).toBeUndefined()
+    expect(wrapper.attributes('tabindex')).toBeUndefined()
+    expect(wrapper.emitted('click')).toBeUndefined()
   })
 })

--- a/tests/unit/switch.spec.js
+++ b/tests/unit/switch.spec.js
@@ -2,7 +2,7 @@ import { mount } from '@vue/test-utils'
 import Switch from '@/components/switch'
 
 describe('BoSwitch', () => {
-  it('uses the initial v-model value', () => {
+  it('reflects value prop updates in the native input', async () => {
     const wrapper = mount(Switch, {
       propsData: {
         value: true
@@ -11,9 +11,13 @@ describe('BoSwitch', () => {
 
     expect(Switch.name).toBe('bo-switch')
     expect(wrapper.get('input').element.checked).toBe(true)
+
+    await wrapper.setProps({ value: false })
+
+    expect(wrapper.get('input').element.checked).toBe(false)
   })
 
-  it('emits the updated boolean when changed', async () => {
+  it('emits the Vue 2 v-model and change contracts', async () => {
     const wrapper = mount(Switch, {
       propsData: {
         value: true
@@ -22,6 +26,20 @@ describe('BoSwitch', () => {
 
     await wrapper.get('input').setChecked(false)
 
+    expect(wrapper.emitted('input')).toEqual([[false]])
     expect(wrapper.emitted('change')).toEqual([[false]])
+  })
+
+  it('forwards disabled and accessible-label state', () => {
+    const wrapper = mount(Switch, {
+      propsData: {
+        disabled: true,
+        ariaLabel: 'Airplane mode'
+      }
+    })
+    const input = wrapper.get('input')
+
+    expect(input.attributes('disabled')).toBe('disabled')
+    expect(input.attributes('aria-label')).toBe('Airplane mode')
   })
 })


### PR DESCRIPTION
## What changed

- make `Switch` implement the Vue 2 `v-model` contract, reflect controlled prop updates, and support disabled/accessible labels
- make `Button` default to the form-safe native `button` type, support explicit native types, and expose loading state to assistive technology
- give interactive `CellItem` instances button semantics and Enter/Space keyboard activation
- add regression coverage and a maintained component API baseline to the documentation

## Why

The historical interactive components had incomplete browser and framework contracts: `Switch` emitted `change` but not the Vue 2 `input` event, `Button` relied on the browser's form-dependent default type, and `CellItem` exposed mouse-only interaction.

## Impact

Existing documented behavior remains available. Consumers gain working Vue 2 `v-model`, safer buttons inside forms, keyboard-accessible cells, and explicit API guidance.

## Validation

- `npm run test:unit` — 3 suites, 12 tests passed
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `npm run audit:prod` — gate passed; one known low-severity Vue 2 advisory remains
- `git diff --check`

Closes #37
