### PR TITLE
Refresh CI action runtimes and update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,16 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
   pull_request:
     branches:
       - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -19,10 +24,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/docs/FAQ/changelog.md
+++ b/docs/FAQ/changelog.md
@@ -9,6 +9,7 @@
 8. 增加 Button、Switch、Cell 组件 smoke tests，并明确移动端浏览器支持基线
 9. 完善 Switch 的 Vue 2 v-model、Button 表单安全和 CellItem 键盘操作契约
 10. 增加核心组件 API 维护基线及对应回归测试
+11. 升级 GitHub Actions 运行时，增加并发取消与 Actions 依赖自动更新
 
 ### 2019-08-08
 1. 增加Picker组件


### PR DESCRIPTION
## What changed

- upgrade `actions/checkout` and `actions/setup-node` from v4 to v6 so CI actions run on the maintained Node.js 24 runtime
- disable persisted checkout credentials because this read-only verification job never pushes
- add manual dispatch and cancel superseded runs for the same workflow/ref
- make Dependabot monitor GitHub Actions monthly and group minor/patch updates
- record the maintenance work in the changelog

## Why

The latest `master` run completed successfully but emitted a deprecation annotation because the v4 actions use the retired Node.js 20 action runtime. GitHub Actions dependencies were also outside the existing Dependabot configuration.

## Impact

CI behavior and project outputs remain unchanged. Maintainers get warning-free action runtimes, fewer wasted runs on superseded commits, manual CI dispatch, and low-noise action update pull requests.

## Validation

- automation configuration assertions passed
- `npm run test:unit` — 3 suites, 12 tests passed
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `npm run audit:prod` — gate passed; one known low-severity Vue 2 advisory remains
- `git diff --check`

Closes #39
