### PR TITLE
Coordinate Vue companion dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+      # Vue 2 runtime and compiler changes must be evaluated together. An
+      # independent compiler update fails CI with a package version mismatch.
+      - dependency-name: vue
+      - dependency-name: vue-template-compiler
 
   - package-ecosystem: github-actions
     directory: /

--- a/docs/FAQ/changelog.md
+++ b/docs/FAQ/changelog.md
@@ -10,6 +10,7 @@
 9. 完善 Switch 的 Vue 2 v-model、Button 表单安全和 CellItem 键盘操作契约
 10. 增加核心组件 API 维护基线及对应回归测试
 11. 升级 GitHub Actions 运行时，增加并发取消与 Actions 依赖自动更新
+12. 审查并升级 GitHub Actions v7，阻止 Vue 核心与编译器的非协调更新
 
 ### 2019-08-08
 1. 增加Picker组件


### PR DESCRIPTION
## What changed

- tell Dependabot not to update `vue` or `vue-template-compiler` independently
- keep all other npm and GitHub Actions update automation enabled
- record today's Actions v7 upgrades and Vue dependency triage in the changelog

## Why

Dependabot PR #42 updated only `vue-template-compiler` to 2.7.16 while the runtime stayed on Vue 2.6.14. CI failed before running any tests with an explicit Vue package version mismatch. Runtime, compiler, loader, and test compatibility need to be evaluated together as part of the planned migration in #34.

## Impact

This removes a source of guaranteed-red bot pull requests without weakening updates for unrelated dependencies. The tested Vue 2.6.14 baseline remains unchanged.

## Validation

- Dependabot YAML parse and policy assertions passed
- `npm run test:unit` — 3 suites, 12 tests passed
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `npm run audit:prod` — gate passed; one known low-severity Vue 2 advisory remains
- `git diff --check`

Closes #44
