### PR TITLE
Restore native Checkbox and Radio interaction contracts

### DIFF
--- a/docs/Comp/checkbox.md
+++ b/docs/Comp/checkbox.md
@@ -11,6 +11,9 @@ Vue.component(Checkbox.name, Checkbox);
 Checkbox组件可以单独使用，也可以组合使用。
 :::
 
+组件会渲染原生 `input[type="checkbox"]`，支持键盘焦点、Space 切换和辅助技术。
+无可见文本时可直接传入 `aria-label`。
+
 #### 单独使用
 <ClientOnly>
 <Common-code-format>
@@ -106,20 +109,27 @@ export default {
 | ------------- |:------------------------------------------------ | :-------------: | :-----: |
 | disabled      | 是否禁用                                          | Boolean         | false  |
 | iconSize      | icon尺寸                                          | String          | 24px   |
-| value         | 是否选中(等于trueValue选中,等于falseValue未选中)    | B/S             | false  |
-| trueValue     | 选中状态时的值                                     | String          |        |
-| falseValue    | 未选中状态的值                                     | String          |        |
-| label         | 需配合CheckboxGroup使用，表示该Checkbox被选中时的值 | String           |        |
+| value         | 是否选中（等于 trueValue 选中，等于 falseValue 未选中） | String / Number / Boolean | false |
+| trueValue     | 选中状态时的值                                     | String / Number / Boolean | true  |
+| falseValue    | 未选中状态的值                                     | String / Number / Boolean | false |
+| label         | 需配合 CheckboxGroup 使用，表示选中时的值           | String / Number / Boolean |       |
+
+#### Checkbox Events
+| 事件名        | 说明                                      | 回调参数 |
+| ------------- |:------------------------------------------| :------: |
+| input         | Vue 2 v-model 更新事件                     | 当前值   |
+| change        | 独立 Checkbox 状态变化事件                  | 当前值   |
 
 
-#### CheckboxBroup Props
+#### CheckboxGroup Props
 | 参数           | 说明                                       | 类型   | 默认值
 | ------------- |:------------------------------------------ | :-----: | :-----: |
 | v-model       | 被选中的值                                  | Array   | []     |
 | max           | 最多选择几个                                | Number  |         |
 | disabled      | 是否禁用                                    | Boolean | false   |
+| aria-label    | 复选框组的无障碍名称                         | String  |         |
 
-#### CheckboxBroup Events
+#### CheckboxGroup Events
 | 事件名           | 说明                                         | 类型    | 默认值
 | ------------- |:---------------------------------------------- | :-----: | :-----: |
 | change        | Checkbox被选中触发，参数为被选中Checkbox的label  | Function  |         |

--- a/docs/Comp/radio.md
+++ b/docs/Comp/radio.md
@@ -7,6 +7,9 @@ Vue.component(RadioGroup.name, RadioGroup);
 Vue.component(Radio.name, Radio);
 ```
 
+组件会渲染原生 `input[type="radio"]`，支持键盘焦点和原生单选交互。
+RadioGroup 会为组内控件生成一致的 `name`，也可以通过 `name` 属性显式指定。
+
 #### 基本用法
 <ClientOnly>
 <Common-code-format>
@@ -93,7 +96,14 @@ export default {
 | ------------- |:------------------------------------------------ | :-------------: | :-----: |
 | disabled      | 是否禁用                                          | Boolean         | false  |
 | iconSize      | icon尺寸                                          | String          | 24px   |
-| label         | 需配合RadioGroup使用，被选中时的值                  | String           |        |
+| label         | 被选中时写入 v-model 的值                           | String / Number  |        |
+| name          | 独立 Radio 的原生 name                              | String           |        |
+
+#### Radio Events
+| 事件名        | 说明                                      | 回调参数 |
+| ------------- |:------------------------------------------| :------: |
+| input         | Vue 2 v-model 更新事件                     | label    |
+| change        | 独立 Radio 选中事件                         | label    |
 
 
 #### RadioGroup Props
@@ -101,6 +111,8 @@ export default {
 | ------------- |:------------------------------------------ | :-----: | :-----: |
 | v-model	    | 当前选中的标识                              | String  |         |
 | disabled      | 是否禁用                                    | Boolean | false   |
+| name          | 组内原生 Radio 共用的 name                  | String  | 自动生成 |
+| aria-label    | 单选组的无障碍名称                           | String  |         |
 
 #### RadioGroup Events
 | 事件名           | 说明                                     | 类型      | 默认值

--- a/docs/FAQ/changelog.md
+++ b/docs/FAQ/changelog.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
-暂无。
+1. 恢复 Checkbox 与 Radio 的原生表单语义、键盘操作和受控状态契约
+2. 增加 Checkbox/Radio 回归测试，覆盖自定义值、分组限制和原生 name
 
 ### 0.2.0-alpha.1 - 2026-08-07
 

--- a/docs/FAQ/component-api.md
+++ b/docs/FAQ/component-api.md
@@ -1,7 +1,7 @@
 # 组件 API 维护基线
 
 borderUI 恢复维护后，将文档、单元测试和持续集成共同覆盖的接口视为当前维护基线。
-现阶段该基线优先覆盖 `Button`、`Switch`、`Cell` 和 `CellItem`；其他历史组件仍可使用，
+现阶段该基线优先覆盖 `Button`、`Switch`、`Cell`、`CellItem`、`Checkbox` 和 `Radio`；其他历史组件仍可使用，
 但在补齐自动化验证前，其接口应视为待确认状态。
 
 ## 稳定交互契约
@@ -35,6 +35,14 @@ borderUI 恢复维护后，将文档、单元测试和持续集成共同覆盖�
 - `isLink` 或 `clickable` 为 `true` 时，`CellItem` 具有按钮语义并进入键盘焦点顺序。
 - 交互式 `CellItem` 支持鼠标点击、Enter 和 Space 激活，并触发 `click`。
 - 静态 `CellItem` 不会声明按钮语义。
+
+### Checkbox 与 Radio
+
+- Checkbox 和 Radio 均渲染受控的原生表单输入，支持键盘和辅助技术。
+- 独立 Checkbox 支持 `trueValue`、`falseValue`、`input` 和 `change` 契约。
+- CheckboxGroup 支持数组 `v-model`、`max` 限制和组级禁用状态。
+- 独立 Radio 通过 `value === label` 判断选中状态。
+- RadioGroup 为组内原生输入提供一致的 `name`，并支持 `radiogroup` 语义。
 
 ## 兼容性与变更原则
 

--- a/src/components/checkbox/checkbox-group.vue
+++ b/src/components/checkbox/checkbox-group.vue
@@ -1,5 +1,9 @@
 <template>
-  <div>
+  <div
+    role="group"
+    :aria-label="ariaLabel"
+    :aria-disabled="disabled ? 'true' : null"
+  >
     <slot></slot>
   </div>
 </template>
@@ -12,8 +16,12 @@ export default {
       type: Array,
       required: true
     },
-    max: Number,
-    disabled: { type: Boolean }
+    max: {
+      type: Number,
+      validator: value => value >= 0
+    },
+    disabled: Boolean,
+    ariaLabel: String
   },
   watch: {
     value (newValue) {
@@ -23,17 +31,27 @@ export default {
   methods: {
     selectItem (item) {
       const { value } = this
-      if (this.max && this.value.length >= this.max) {
-        return
+      if (value.some(selectedItem => selectedItem === item)) {
+        return false
       }
+
+      if (this.max !== undefined && value.length >= this.max) return false
+
       this.$emit('input', [...value, item])
+      return true
     },
     deleteItem (item) {
       const { value: selectItems } = this
+
+      if (!selectItems.some(selectItem => selectItem === item)) {
+        return false
+      }
+
       this.$emit(
         'input',
         selectItems.filter(selectitem => selectitem !== item)
       )
+      return true
     }
   }
 }

--- a/src/components/checkbox/checkbox.vue
+++ b/src/components/checkbox/checkbox.vue
@@ -1,39 +1,50 @@
 <template>
   <div>
-    <span
+    <label
       :class="[
         'checkbox-item',
         { 'is-checked': isChecked },
         { 'is-disabled': isDisabled },
         { 'is-group': isGroup }
       ]"
-      @click.stop="toggle"
+      @click.stop
     >
       <input
-        v-if="false"
-        type="checkbox"
         v-bind="$attrs"
-        :disabled="disabled"
-        :value="model"
+        class="checkbox-native"
+        type="checkbox"
+        :checked="isChecked"
+        :disabled="isDisabled"
+        :value="label === undefined ? trueValue : label"
+        @change="onChange"
       >
       <span class="checkbox-inner">
         <bo-icon name="radio-checked" :size=iconSize color="#CCC"/>
-        <span class="slot-value">
+        <span class="slot-value" :style="{ fontSize: textSize }">
           <slot></slot>
         </span>
       </span>
-    </span>
+    </label>
   </div>
 </template>
 
 <style lang="stylus" scoped>
 @import '../../style/var';
 .checkbox-item
+  position relative
+  cursor pointer
   &.is-group
     display inline-block
     padding 2px 0
-  input
-    appearance none
+  .checkbox-native
+    position absolute
+    width 1px
+    height 1px
+    opacity 0
+    pointer-events none
+    &:focus + .checkbox-inner
+      outline 2px solid $theme-color
+      outline-offset 2px
   .checkbox-inner
     i,span
       vertical-align middle
@@ -41,6 +52,7 @@
     i.iconfont
       color $theme-color !important
   &.is-disabled
+    cursor not-allowed
     i.iconfont
       color #CCC
     .slot-value
@@ -54,6 +66,7 @@ import { findComponentUpward } from '../utils/assist'
 
 export default {
   name: 'bo-checkbox',
+  inheritAttrs: false,
   props: {
     disabled: {
       type: Boolean,
@@ -67,7 +80,7 @@ export default {
       type: String,
       default: '14px'
     },
-    label: String,
+    label: [String, Number, Boolean],
     value: {
       type: [String, Number, Boolean],
       default: false
@@ -88,28 +101,11 @@ export default {
     }
   },
   computed: {
-    model: {
-      get () {
-        return this.isGroup ? this.parent.value : this.currentValue
-      },
-      set (newValue) {
-        const { isGroup, isChecked } = this
-
-        if (isGroup) {
-          isChecked
-            ? this.parent.deleteItem(this.label || '')
-            : this.parent.selectItem(this.label || '')
-        } else {
-          this.$emit('input', newValue)
-        }
-      }
-    },
     isDisabled () {
       return (this.parent && this.parent.disabled) || this.disabled
     },
     isChecked () {
-      const { isGroup, model } = this
-      if (!isGroup) return model
+      if (!this.isGroup) return this.currentValue
 
       const {
         label,
@@ -121,7 +117,7 @@ export default {
       if (this.value === this.trueValue || this.value === this.falseValue) {
         return this.value === this.trueValue
       } else {
-        throw 'Value should be trueValue or falseValue.'
+        throw new Error('Value should be trueValue or falseValue.')
       }
     }
   },
@@ -130,11 +126,30 @@ export default {
     this.parent ? this.isGroup = true : this.isGroup = false
   },
   methods: {
-    toggle (event) {
-      const { isDisabled, isGroup, model, value } = this
-      if (!isDisabled) {
-        this.model = isGroup ? value : !model
+    onChange (event) {
+      const accepted = this.updateChecked(event.target.checked)
+
+      if (!accepted) {
+        event.target.checked = this.isChecked
       }
+    },
+    updateChecked (checked) {
+      if (this.isDisabled) return false
+
+      if (this.isGroup) {
+        const label = this.label === undefined ? '' : this.label
+        return checked
+          ? this.parent.selectItem(label)
+          : this.parent.deleteItem(label)
+      }
+
+      const nextValue = checked ? this.trueValue : this.falseValue
+      this.$emit('input', nextValue)
+      this.$emit('change', nextValue)
+      return true
+    },
+    toggle () {
+      return this.updateChecked(!this.isChecked)
     }
   }
 }

--- a/src/components/radio/radio-group.vue
+++ b/src/components/radio/radio-group.vue
@@ -1,6 +1,8 @@
 <template>
   <div
-    name="radio-group"
+    role="radiogroup"
+    :aria-label="ariaLabel"
+    :aria-disabled="disabled ? 'true' : null"
     :class="[
       'radio-group'
     ]"
@@ -13,7 +15,14 @@ export default {
   name: 'bo-radio-group',
   props: {
     value: { type: [String, Number] },
-    disabled: { type: Boolean }
+    disabled: Boolean,
+    name: String,
+    ariaLabel: String
+  },
+  computed: {
+    nativeName () {
+      return this.name || `bo-radio-group-${this._uid}`
+    }
   },
   watch: {
     value (newValue) {

--- a/src/components/radio/radio.vue
+++ b/src/components/radio/radio.vue
@@ -1,21 +1,31 @@
 <template>
 <div>
-  <span
+  <label
     :class="[
       'radio-item',
       { 'is-checked': isChecked },
       { 'is-disabled': isDisabled },
       { 'is-group': isGroup }
     ]"
-    @click.stop="toggle"
+    @click.stop
   >
+    <input
+      v-bind="$attrs"
+      class="radio-native"
+      type="radio"
+      :name="nativeName"
+      :value="label"
+      :checked="isChecked"
+      :disabled="isDisabled"
+      @change="onChange"
+    >
     <span class="radio-inner">
       <bo-icon :name=iconName :size=iconSize :color=iconColor />
       <span class="slot-value">
         <slot></slot>
       </span>
     </span>
-  </span>
+  </label>
 </div>
 
 </template>
@@ -24,11 +34,13 @@
 import { findComponentUpward } from '../utils/assist'
 export default {
   name: 'bo-radio',
+  inheritAttrs: false,
   props: {
     value: {
       type: [String, Number]
     },
-    label: String,
+    label: [String, Number],
+    name: String,
     iconSize: {
       type: String,
       default: '24px'
@@ -63,14 +75,10 @@ export default {
       return (this.parent && this.parent.disabled) || this.disabled
     },
     isChecked () {
-      const { isGroup, model } = this
-      if (!isGroup) return model
-
-      const {
-        label,
-        parent: { value: selectItem }
-      } = this
-      return selectItem === label
+      return this.model === this.label
+    },
+    nativeName () {
+      return this.isGroup ? this.parent.nativeName : this.name
     },
     model: {
       get () {
@@ -86,8 +94,18 @@ export default {
     this.parent ? this.isGroup = true : this.isGroup = false
   },
   methods: {
-    toggle (event) {
-      !this.isDisabled && (this.model = this.label)
+    onChange (event) {
+      if (event.target.checked) this.select()
+    },
+    select () {
+      if (this.isDisabled || this.isChecked) return false
+
+      this.model = this.label
+      if (!this.isGroup) this.$emit('change', this.label)
+      return true
+    },
+    toggle () {
+      return this.select()
     }
   }
 }
@@ -96,13 +114,25 @@ export default {
 <style lang="stylus" scoped>
 @import '../../style/var';
 .radio-item
+  position relative
+  cursor pointer
   &.is-group
     display inline-block
     padding 2px 0
   &.is-checked
     color $theme-color
   &.is-disabled
+    cursor not-allowed
     color #CCC
+  .radio-native
+    position absolute
+    width 1px
+    height 1px
+    opacity 0
+    pointer-events none
+    &:focus + .radio-inner
+      outline 2px solid $theme-color
+      outline-offset 2px
   .radio-inner
     i,span
       vertical-align middle

--- a/tests/unit/form-controls.spec.js
+++ b/tests/unit/form-controls.spec.js
@@ -1,0 +1,129 @@
+import { mount } from '@vue/test-utils'
+import { Checkbox, CheckboxGroup } from '@/components/checkbox'
+import { Radio, RadioGroup } from '@/components/radio'
+
+const stubs = {
+  'bo-icon': true
+}
+
+describe('Checkbox controls', () => {
+  it('renders a controlled native input and supports custom values', async () => {
+    const wrapper = mount(Checkbox, {
+      propsData: {
+        value: 'no',
+        trueValue: 'yes',
+        falseValue: 'no'
+      },
+      stubs
+    })
+    const input = wrapper.get('input[type="checkbox"]')
+
+    expect(input.element.checked).toBe(false)
+
+    input.element.checked = true
+    await input.trigger('change')
+
+    expect(wrapper.emitted('input')).toEqual([['yes']])
+    expect(wrapper.emitted('change')).toEqual([['yes']])
+
+    await wrapper.setProps({ value: 'yes' })
+
+    expect(input.element.checked).toBe(true)
+  })
+
+  it('forwards disabled and accessible input attributes', () => {
+    const wrapper = mount(Checkbox, {
+      attrs: {
+        'aria-label': 'Accept terms'
+      },
+      propsData: {
+        disabled: true
+      },
+      stubs
+    })
+    const input = wrapper.get('input')
+
+    expect(input.attributes('disabled')).toBe('disabled')
+    expect(input.attributes('aria-label')).toBe('Accept terms')
+  })
+
+  it('rejects new group selections after reaching max', async () => {
+    const wrapper = mount({
+      components: {
+        BoCheckbox: Checkbox,
+        BoCheckboxGroup: CheckboxGroup
+      },
+      data () {
+        return {
+          selected: ['A']
+        }
+      },
+      template: `
+        <bo-checkbox-group v-model="selected" :max="1" aria-label="Choices">
+          <bo-checkbox label="A">A</bo-checkbox>
+          <bo-checkbox label="B">B</bo-checkbox>
+        </bo-checkbox-group>
+      `
+    }, { stubs })
+    const inputs = wrapper.findAll('input')
+
+    inputs.at(1).element.checked = true
+    await inputs.at(1).trigger('change')
+
+    expect(wrapper.vm.selected).toEqual(['A'])
+    expect(inputs.at(1).element.checked).toBe(false)
+    expect(wrapper.get('[role="group"]').attributes('aria-label')).toBe('Choices')
+  })
+})
+
+describe('Radio controls', () => {
+  it('compares a standalone model with its label', async () => {
+    const wrapper = mount(Radio, {
+      propsData: {
+        value: 'B',
+        label: 'A',
+        name: 'standalone-choice'
+      },
+      stubs
+    })
+    const input = wrapper.get('input[type="radio"]')
+
+    expect(input.element.checked).toBe(false)
+
+    input.element.checked = true
+    await input.trigger('change')
+
+    expect(wrapper.emitted('input')).toEqual([['A']])
+    expect(wrapper.emitted('change')).toEqual([['A']])
+    expect(input.attributes('name')).toBe('standalone-choice')
+  })
+
+  it('uses one generated native name and updates grouped v-model', async () => {
+    const wrapper = mount({
+      components: {
+        BoRadio: Radio,
+        BoRadioGroup: RadioGroup
+      },
+      data () {
+        return {
+          selected: 'A'
+        }
+      },
+      template: `
+        <bo-radio-group v-model="selected" aria-label="Fruit">
+          <bo-radio label="A">A</bo-radio>
+          <bo-radio label="B">B</bo-radio>
+        </bo-radio-group>
+      `
+    }, { stubs })
+    const inputs = wrapper.findAll('input')
+
+    expect(inputs.at(0).attributes('name')).toBe(inputs.at(1).attributes('name'))
+    expect(wrapper.get('[role="radiogroup"]').attributes('aria-label')).toBe('Fruit')
+
+    inputs.at(1).element.checked = true
+    await inputs.at(1).trigger('change')
+
+    expect(wrapper.vm.selected).toBe('B')
+  })
+})


### PR DESCRIPTION
## What

- restore native checkbox and radio inputs instead of mouse-only wrappers
- preserve controlled Vue 2 `v-model` behavior, including Checkbox custom values and group limits
- fix standalone Radio selection to compare `value` with `label`
- add group semantics, shared native radio names, disabled propagation, and focus styles
- document the maintained contracts and add five regression tests

## Why

The historical components either hid the native input behind `v-if="false"` or did not render one at all. This made keyboard and assistive-technology interaction unavailable, and standalone Radio treated any truthy model as selected.

## Validation

- `npm run test:unit` (4 suites, 17 tests)
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `npm run audit:prod` (passes the high-severity gate; one known low-severity Vue 2 advisory remains)

Closes #48
