### PR TITLE
Prepare v0.2.0-alpha.2 prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
   <a href="https://github.com/border1px/borderUI/actions/workflows/ci.yml">
     <img alt="CI status" src="https://github.com/border1px/borderUI/actions/workflows/ci.yml/badge.svg">
   </a>
-  <a href="https://github.com/border1px/borderUI/releases/tag/v0.2.0-alpha.1">
-    <img alt="Release: v0.2.0-alpha.1" src="https://img.shields.io/badge/release-v0.2.0--alpha.1-orange.svg">
+  <a href="https://github.com/border1px/borderUI/releases/tag/v0.2.0-alpha.2">
+    <img alt="Release: v0.2.0-alpha.2" src="https://img.shields.io/badge/release-v0.2.0--alpha.2-orange.svg">
   </a>
 </p>
 
@@ -38,7 +38,7 @@ Do not confuse it with the unrelated `border-1px` package on npm.
 - [Documentation](https://border1px.github.io/border-ui/docs/FAQ/introduction.html)
 - [Maintained component API](docs/FAQ/component-api.md)
 - [Interactive demo](https://border1px.github.io/border-ui/)
-- [Latest maintenance prerelease](https://github.com/border1px/borderUI/releases/tag/v0.2.0-alpha.1)
+- [Latest maintenance prerelease](https://github.com/border1px/borderUI/releases/tag/v0.2.0-alpha.2)
 - [Maintenance roadmap](ROADMAP.md)
 - [Release process and branch strategy](RELEASING.md)
 - [How to contribute](CONTRIBUTING.md)

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,6 +42,7 @@ module.exports = {
           ['/FAQ/introduction','介绍'],
           ['/FAQ/quickstart','快速上手'],
           ['/FAQ/component-api','组件 API 维护基线'],
+          ['/FAQ/release-0.2.0-alpha.2','v0.2.0-alpha.2 发布说明'],
           ['/FAQ/release-0.2.0-alpha.1','v0.2.0-alpha.1 发布说明'],
           ['/FAQ/changelog','更新日志'],
           ['/FAQ/aboutme','与我有关'],

--- a/docs/FAQ/changelog.md
+++ b/docs/FAQ/changelog.md
@@ -1,7 +1,13 @@
 ### Unreleased
 
+暂无。
+
+### 0.2.0-alpha.2 - 2026-08-08
+
 1. 恢复 Checkbox 与 Radio 的原生表单语义、键盘操作和受控状态契约
 2. 增加 Checkbox/Radio 回归测试，覆盖自定义值、分组限制和原生 name
+
+完整兼容性、限制和升级说明见 [v0.2.0-alpha.2 发布说明](release-0.2.0-alpha.2.md)。
 
 ### 0.2.0-alpha.1 - 2026-08-07
 

--- a/docs/FAQ/release-0.2.0-alpha.2.md
+++ b/docs/FAQ/release-0.2.0-alpha.2.md
@@ -1,0 +1,77 @@
+# v0.2.0-alpha.2 form controls prerelease
+
+Released: 2026-08-08
+
+This maintenance prerelease builds on the reproducible baseline established in
+`v0.2.0-alpha.1`. It focuses on making Checkbox and Radio usable as native,
+controlled form controls while preserving the existing Vue 2 component API.
+It is a verified source and demo release, not an npm publication.
+
+## Highlights
+
+- Restored the native `input[type="checkbox"]` previously disabled by the
+  component template.
+- Added a native `input[type="radio"]` to Radio.
+- Restored keyboard focus, Space activation, disabled propagation, and
+  assistive-technology semantics.
+- Fixed standalone Radio selection so checked state is based on
+  `value === label`, rather than model truthiness.
+- Preserved controlled Vue 2 `v-model` updates and added explicit standalone
+  `change` events.
+- Preserved Checkbox custom `trueValue` and `falseValue` values.
+- Made CheckboxGroup reject duplicate or over-limit selections without leaving
+  the native input in a stale visual state; a numeric `max` of `0` is now
+  handled correctly.
+- Added group roles, accessible labels, and a shared native name for grouped
+  radios.
+- Expanded the maintained API baseline from four to six component families and
+  increased the unit suite from 12 to 17 tests.
+
+The implementation was reviewed and verified through [pull request #49](https://github.com/border1px/borderUI/pull/49).
+
+## Compatibility
+
+- Vue: 2.6.14
+- Node.js: 22 or newer
+- Package manager: npm 11 with the committed lockfile
+- Browsers: iOS 12+, Android 8+, and the last two versions of actively
+  maintained browsers
+
+The tagged source passes the production dependency gate, lint, all 17 unit
+tests, the application build, and the documentation build.
+
+## Known limitations
+
+- Vue 2, Vue CLI 5, and VuePress 1 are end-of-life dependencies.
+- The repository remains marked `private` in `package.json`; no package is
+  published to npm under the `border-1px` name.
+- The demo bundle still reports webpack size recommendations.
+- VuePress 1 produces deprecation notices on current Node.js releases.
+- A low-severity Vue 2 ReDoS advisory remains. The available automated fix
+  requires a breaking Vue 3 upgrade and is therefore outside this prerelease.
+- Historical components outside the maintained API baseline may still contain
+  unverified edge cases.
+
+## Upgrade and usage
+
+There is no npm upgrade command for this prerelease. Test against the tagged
+source instead:
+
+```bash
+git fetch --tags
+git checkout v0.2.0-alpha.2
+npm ci
+npm run test:unit
+npm run build
+```
+
+Checkbox and Radio users should review the updated
+[component API baseline](component-api.md), [Checkbox documentation](../Comp/checkbox.md),
+and [Radio documentation](../Comp/radio.md). The restored inputs improve native
+behavior without changing the component names or Vue 2 `v-model` event.
+
+## Next steps
+
+The `release/0.2` branch follows the latest verified 0.2 prerelease. Further
+work on `master` will continue expanding regression coverage and preparing the
+Vue 3/Vite and documentation-toolchain migrations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "border-1px",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "border-1px",
-      "version": "0.2.0-alpha.1",
+      "version": "0.2.0-alpha.2",
       "dependencies": {
         "vue": "2.6.14",
         "vue-router": "^3.6.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "border-1px",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "description": "Mobile UI components and demos built with Vue 2",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Release scope

- bump source/demo version metadata to `0.2.0-alpha.2`
- archive the form-control work under the dated changelog entry
- add dedicated compatibility, validation, limitation, and usage notes
- expose both prerelease histories in the documentation sidebar
- point the README release badge and latest-release link at alpha.2

## Included maintenance

This prerelease packages the native Checkbox/Radio interaction and accessibility work merged through #49. It does not publish an npm package and does not change the Vue 2 compatibility baseline.

## Validation

- `npm run test:unit` (4 suites, 17 tests)
- `npm run lint`
- `npm run build`
- `npm run docs:build`
- `npm run audit:prod` (passes the high-severity gate; one documented low-severity Vue 2 advisory remains)

Closes #50
